### PR TITLE
fix: correct file size calculation for directories in grid view

### DIFF
--- a/modules/docs-library/modules/publicDocs/views/public-docs-tab/GridItem.tsx
+++ b/modules/docs-library/modules/publicDocs/views/public-docs-tab/GridItem.tsx
@@ -58,7 +58,7 @@ export default function GridItem({
   const t = useTranslations("docs-library.publicDocs.table.actions");
   const formattedDate = date.toLocaleDateString("en-GB").replace(/\//g, "-");
   // calc file size
-  const fileSize = document?.file?.size;
+  const fileSize = isDir ? document?.size : document?.file?.size;
   const fileSizeInMB = (fileSize || 0) / 1024 / 1024;
   // image url
   let imageUrl = document?.file?.url;

--- a/modules/docs-library/modules/publicDocs/views/public-docs-tab/GridViewMode.tsx
+++ b/modules/docs-library/modules/publicDocs/views/public-docs-tab/GridViewMode.tsx
@@ -29,10 +29,10 @@ export default function GridViewMode() {
           // Show actual grid items when loaded
           <>
             {docs?.folders?.map((folder) => (
-              <GridItem isDir document={folder} key={folder.id} />
+              <GridItem isDir={true} document={folder} key={folder.id} />
             ))}
             {docs?.files?.map((file) => (
-              <GridItem document={file} key={file.id} />
+              <GridItem isDir={false} document={file} key={file.id} />
             ))}
           </>
         )}


### PR DESCRIPTION
- Use document.size for directories instead of document.file.size
- Explicitly pass isDir prop to GridItem components for clarity

