### PR TITLE
feat: add isCentralProject property to sidebar menu items for project…

### DIFF
--- a/components/shared/layout/app-sidebar.tsx
+++ b/components/shared/layout/app-sidebar.tsx
@@ -133,6 +133,18 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
       show: can(Object.values(PERMISSIONS.permission)),
     };
 
+    /**
+     * isCentralProject: "central" | "not-central" | "both";
+     * companies: central
+     * users: central
+     * human resources: not-central
+     * program management: central
+     * CRM: not-central
+     * docs library: not-central
+     * settings: central
+     * powers: not-central
+     * ecommerce: not-central
+     */
     const data: Project[] = [
       // companies
       {
@@ -141,6 +153,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         icon: LayoutDashboardIcon,
         isActive: pageName === ROUTER.COMPANIES,
         slug: SUPER_ENTITY_SLUG.COMPANY,
+        isCentralProject: "central",
         sub_entities: [
           {
             name: t("Sidebar.CompaniesList"),
@@ -159,6 +172,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         urls: [ROUTER.USERS],
         isActive: pageName === ROUTER.USERS,
         slug: SUPER_ENTITY_SLUG.USERS,
+        isCentralProject: "central",
         sub_entities: [
           {
             name: t("Sidebar.UsersList"),
@@ -176,6 +190,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         urls: [ROUTER.Organizational_Structure],
         isActive: pageName === ROUTER.Organizational_Structure,
         slug: SUPER_ENTITY_SLUG.HRM,
+        isCentralProject: "not-central",
         sub_entities: [
           {
             name: t("Sidebar.OrganizationalStructure"),
@@ -219,6 +234,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         icon: LayoutDashboardIcon,
         urls: [ROUTER.PROGRAM_SETTINGS.USERS],
         isActive: pageName === ROUTER.PROGRAM_SETTINGS.USERS,
+        isCentralProject: "central",
         sub_entities: [
           {
             name: t("Sidebar.Users"),
@@ -236,6 +252,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         icon: LayoutDashboardIcon,
         urls: [ROUTER.CRM.clients, ROUTER.CRM.brokers, ROUTER.CRM.settings],
         isActive: pageName === ROUTER.CRM.clients,
+        isCentralProject: "not-central",
         sub_entities: [
           {
             name: t("Sidebar.CRMSettings"),
@@ -253,6 +270,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         icon: LibraryBig,
         urls: [ROUTER.DOCS_LIBRARY],
         isActive: pageName === ROUTER.DOCS_LIBRARY,
+        isCentralProject: "not-central",
         sub_entities: [
           {
             name: t("Sidebar.docs-library-docs"),
@@ -270,6 +288,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         isActive: settingsRoutesNames.indexOf(pageName) !== -1,
         slug: SUPER_ENTITY_SLUG.SETTINGS,
         urls: [ROUTER.USER_PROFILE, ROUTER.COMPANY_PROFILE, ROUTER.SETTINGS],
+        isCentralProject: "central",
         sub_entities: [
           {
             name: t("Sidebar.UserProfileSettings"),
@@ -325,6 +344,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         isActive: pageName === ROUTER.Powers,
         slug: SUPER_ENTITY_SLUG.POWERS,
         urls: [ROUTER.Programs],
+        isCentralProject: "not-central",
         sub_entities: [
           {
             name: t("Sidebar.PackagesAndPrograms"),
@@ -351,6 +371,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
           ROUTER.Discounts,
           ROUTER.Coupons,
         ].includes(pageName),
+        isCentralProject: "not-central",
         slug: SUPER_ENTITY_SLUG.ECOMMERCE,
         urls: [
           ROUTER.HomeStore,
@@ -457,13 +478,15 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
       data,
       isSuperAdmin
     );
-    const _shownProjects = _mergedProjects?.filter((project) => {
+    const _shownProjects = _mergedProjects?.filter(project => {
+      return (isCentralCompany && project.isCentralProject === "central") ||
+        (!isCentralCompany && project.isCentralProject === "not-central") ||
+        (project.isCentralProject === "both");
+    })?.filter((project) => {
       return project.sub_entities?.some((subEntity) => subEntity.show);
     });
     return _shownProjects;
   }, [SidebarProjects, isLoading, data, isSuperAdmin, mergeProjectsAndMenu]);
-
-  console.log('all101', all)
 
   return (
     <Sidebar

--- a/components/shared/layout/app-sidebar.tsx
+++ b/components/shared/layout/app-sidebar.tsx
@@ -288,7 +288,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         isActive: settingsRoutesNames.indexOf(pageName) !== -1,
         slug: SUPER_ENTITY_SLUG.SETTINGS,
         urls: [ROUTER.USER_PROFILE, ROUTER.COMPANY_PROFILE, ROUTER.SETTINGS],
-        isCentralProject: "central",
+        isCentralProject: "both",
         sub_entities: [
           {
             name: t("Sidebar.UserProfileSettings"),
@@ -344,7 +344,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         isActive: pageName === ROUTER.Powers,
         slug: SUPER_ENTITY_SLUG.POWERS,
         urls: [ROUTER.Programs],
-        isCentralProject: "not-central",
+        isCentralProject: "central",
         sub_entities: [
           {
             name: t("Sidebar.PackagesAndPrograms"),

--- a/components/shared/layout/app-sidebar.tsx
+++ b/components/shared/layout/app-sidebar.tsx
@@ -141,8 +141,8 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
      * program management: central
      * CRM: not-central
      * docs library: not-central
-     * settings: central
-     * powers: not-central
+     * settings: both
+     * powers: central
      * ecommerce: not-central
      */
     const data: Project[] = [

--- a/components/shared/layout/app-sidebar.tsx
+++ b/components/shared/layout/app-sidebar.tsx
@@ -134,7 +134,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
     };
 
     /**
-     * isCentralProject: "central" | "not-central" | "both";
+     * show calculation based on company type:
      * companies: central
      * users: central
      * human resources: not-central
@@ -153,7 +153,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         icon: LayoutDashboardIcon,
         isActive: pageName === ROUTER.COMPANIES,
         slug: SUPER_ENTITY_SLUG.COMPANY,
-        isCentralProject: "central",
+        show: isCentralCompany,
         sub_entities: [
           {
             name: t("Sidebar.CompaniesList"),
@@ -172,7 +172,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         urls: [ROUTER.USERS],
         isActive: pageName === ROUTER.USERS,
         slug: SUPER_ENTITY_SLUG.USERS,
-        isCentralProject: "central",
+        show: isCentralCompany,
         sub_entities: [
           {
             name: t("Sidebar.UsersList"),
@@ -190,7 +190,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         urls: [ROUTER.Organizational_Structure],
         isActive: pageName === ROUTER.Organizational_Structure,
         slug: SUPER_ENTITY_SLUG.HRM,
-        isCentralProject: "not-central",
+        show: !isCentralCompany,
         sub_entities: [
           {
             name: t("Sidebar.OrganizationalStructure"),
@@ -234,7 +234,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         icon: LayoutDashboardIcon,
         urls: [ROUTER.PROGRAM_SETTINGS.USERS],
         isActive: pageName === ROUTER.PROGRAM_SETTINGS.USERS,
-        isCentralProject: "central",
+        show: isCentralCompany,
         sub_entities: [
           {
             name: t("Sidebar.Users"),
@@ -252,7 +252,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         icon: LayoutDashboardIcon,
         urls: [ROUTER.CRM.clients, ROUTER.CRM.brokers, ROUTER.CRM.settings],
         isActive: pageName === ROUTER.CRM.clients,
-        isCentralProject: "not-central",
+        show: !isCentralCompany,
         sub_entities: [
           {
             name: t("Sidebar.CRMSettings"),
@@ -270,7 +270,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         icon: LibraryBig,
         urls: [ROUTER.DOCS_LIBRARY],
         isActive: pageName === ROUTER.DOCS_LIBRARY,
-        isCentralProject: "not-central",
+        show: !isCentralCompany,
         sub_entities: [
           {
             name: t("Sidebar.docs-library-docs"),
@@ -288,7 +288,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         isActive: settingsRoutesNames.indexOf(pageName) !== -1,
         slug: SUPER_ENTITY_SLUG.SETTINGS,
         urls: [ROUTER.USER_PROFILE, ROUTER.COMPANY_PROFILE, ROUTER.SETTINGS],
-        isCentralProject: "both",
+        show: true,
         sub_entities: [
           {
             name: t("Sidebar.UserProfileSettings"),
@@ -344,7 +344,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
         isActive: pageName === ROUTER.Powers,
         slug: SUPER_ENTITY_SLUG.POWERS,
         urls: [ROUTER.Programs],
-        isCentralProject: "central",
+        show: isCentralCompany,
         sub_entities: [
           {
             name: t("Sidebar.PackagesAndPrograms"),
@@ -371,7 +371,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
           ROUTER.Discounts,
           ROUTER.Coupons,
         ].includes(pageName),
-        isCentralProject: "not-central",
+        show: !isCentralCompany,
         slug: SUPER_ENTITY_SLUG.ECOMMERCE,
         urls: [
           ROUTER.HomeStore,
@@ -479,9 +479,7 @@ export function AppSidebar({ name, mainLogo, ...props }: AppSidebarProps) {
       isSuperAdmin
     );
     const _shownProjects = _mergedProjects?.filter(project => {
-      return (isCentralCompany && project.isCentralProject === "central") ||
-        (!isCentralCompany && project.isCentralProject === "not-central") ||
-        (project.isCentralProject === "both");
+      return project.show;
     })?.filter((project) => {
       return project.sub_entities?.some((subEntity) => subEntity.show);
     });

--- a/types/sidebar-menu.ts
+++ b/types/sidebar-menu.ts
@@ -59,7 +59,7 @@ export type Project = {
   urls?: string[];
   icon?: string | ComponentType;
   isActive: boolean;
-  isCentralProject: "central" | "not-central" | "both";
+  show: boolean;
   sub_entities: Entity[];
 };
 

--- a/types/sidebar-menu.ts
+++ b/types/sidebar-menu.ts
@@ -59,6 +59,7 @@ export type Project = {
   urls?: string[];
   icon?: string | ComponentType;
   isActive: boolean;
+  isCentralProject: "central" | "not-central" | "both";
   sub_entities: Entity[];
 };
 


### PR DESCRIPTION
This PR implements a conditional visibility system for the sidebar navigation based on company type (Central vs. Non-Central companies). Different sidebar items are now shown/hidden depending on whether the user belongs to a central company or a regular company.
