### PR TITLE
feat: migrate main categories table to HeadlessTable with two-hook pa…

### DIFF
--- a/messages/groups/stores/index.ts
+++ b/messages/groups/stores/index.ts
@@ -1,6 +1,8 @@
 import { MessagesGroup } from "@/messages/types";
 import { mainCategoriesMessages } from "./main-categories/main-categories";
+import { warehouseMessages } from "./warehouse";
 
 export const storesMessages = new MessagesGroup({
   mainCategories: mainCategoriesMessages,
+  warehouse: warehouseMessages,
 });

--- a/messages/groups/stores/index.ts
+++ b/messages/groups/stores/index.ts
@@ -1,0 +1,6 @@
+import { MessagesGroup } from "@/messages/types";
+import { mainCategoriesMessages } from "./main-categories/main-categories";
+
+export const storesMessages = new MessagesGroup({
+  mainCategories: mainCategoriesMessages,
+});

--- a/messages/groups/stores/main-categories/main-categories.ts
+++ b/messages/groups/stores/main-categories/main-categories.ts
@@ -1,0 +1,8 @@
+import { _m, MessagesGroup } from "@/messages/types";
+import { mainCategoriesTableMessages } from "./table";
+
+export const mainCategoriesMessages = new MessagesGroup({
+  title: _m("Main Categories", "التصنيفات الرئيسية"),
+  // Table messages
+  table: mainCategoriesTableMessages,
+});

--- a/messages/groups/stores/main-categories/table.ts
+++ b/messages/groups/stores/main-categories/table.ts
@@ -1,0 +1,16 @@
+import { _m, MessagesGroup } from "@/messages/types";
+
+export const mainCategoriesTableMessages = new MessagesGroup({
+  category: _m("Category", "القسم"),
+  priority: _m("Priority", "الأولوية"),
+  status: _m("Status", "الحالة"),
+  actions: _m("Actions", "الإجراءات"),
+  action: _m("Action", "الإجراء"),
+  search: _m("Search...", "البحث..."),
+  reset: _m("Reset", "إعادة تعيين"),
+  edit: _m("Edit", "تعديل"),
+  image: _m("Image", "صورة"),
+  add: _m("Add Category", "إضافة قسم"),
+  delete: _m("Delete", "حذف"),
+  deleteConfirm: _m("Are you sure you want to delete this category?", "هل أنت متأكد من حذف هذا القسم؟"),
+});

--- a/messages/groups/stores/warehouse/dialog-location.ts
+++ b/messages/groups/stores/warehouse/dialog-location.ts
@@ -1,0 +1,9 @@
+import { _m, MessagesGroup } from "@/messages/types";
+
+export const warehouseDialogLocationMessages = new MessagesGroup({
+  country: _m("Country", "الدولة"),
+  city: _m("City", "المدينة"),
+  district: _m("District", "الحي"),
+  longitude: _m("Longitude", "خط الطول"),
+  latitude: _m("Latitude", "خط العرض"),
+});

--- a/messages/groups/stores/warehouse/index.ts
+++ b/messages/groups/stores/warehouse/index.ts
@@ -1,0 +1,9 @@
+import { _m, MessagesGroup } from "@/messages/types";
+import { warehouseTableMessages } from "./table";
+
+export const warehouseMessages = new MessagesGroup({
+  title: _m("Warehouses", "المستودعات"),
+  deleteConfirmMessage: _m("Are you sure you want to delete this warehouse?", "هل أنت متأكد من حذف هذا المستودع؟"),
+  // Table messages
+  table: warehouseTableMessages,
+});

--- a/messages/groups/stores/warehouse/table.ts
+++ b/messages/groups/stores/warehouse/table.ts
@@ -1,0 +1,20 @@
+import { _m, MessagesGroup } from "@/messages/types";
+import { warehouseDialogLocationMessages } from "./dialog-location";
+
+export const warehouseTableMessages = new MessagesGroup({
+  name: _m("Name", "الاسم"),
+  default: _m("Default", "افتراضي"),
+  actions: _m("Actions", "الإجراءات"),
+  action: _m("Action", "الإجراء"),
+  search: _m("Search...", "البحث..."),
+  edit: _m("Edit", "تعديل"),
+  delete: _m("Delete", "حذف"),
+  add: _m("Add Warehouse", "إضافة مستودع"),
+  deleteConfirm: _m(
+    "Are you sure you want to delete this warehouse?",
+    "هل أنت متأكد من حذف هذا المستودع؟"
+  ),
+
+  // Location labels
+  location: warehouseDialogLocationMessages,
+});

--- a/messages/structure.ts
+++ b/messages/structure.ts
@@ -54,6 +54,7 @@ import { editSubEntityMessages } from "./groups/edit-sub-entity";
 import { wysiwygMessages } from "./groups/wysiwyg";
 import { clientProfileModuleMessages } from "./groups/client-profile";
 import { companyProfileLegalDataFormMessages } from "./groups/company-profile/legal-data-form";
+import { storesMessages } from "./groups/stores";
 
 // Main messages structure combining all groups
 export const messagesStructure = new MessagesGroup({
@@ -111,6 +112,7 @@ export const messagesStructure = new MessagesGroup({
   requests: requestsMessages,
   paymentMethods: paymentMethodsMessages,
   "content-management-system": contentManagementSystemMessages,
+  stores: storesMessages,
   wysiwyg: wysiwygMessages,
   ClientProfile: clientProfileModuleMessages,
 });

--- a/modules/stores/categories/list/views/main-category/index.tsx
+++ b/modules/stores/categories/list/views/main-category/index.tsx
@@ -1,24 +1,20 @@
 "use client";
 
-import { TableBuilder, useTableReload } from "@/modules/table";
-import { Button } from "@/components/ui/button";
-import DialogTrigger from "@/components/headless/dialog-trigger";
-import AddCategoryDialog from "@/modules/stores/components/dialogs/add-category";
-import { useTranslations } from "next-intl";
 import { useState } from "react";
-import { useMainCategoryTableConfig } from "../../../_config/mainTableConfig";
+import { useTranslations } from "next-intl";
 import Can from "@/lib/permissions/client/Can";
 import { PERMISSIONS } from "@/lib/permissions/permission-names";
+import AddCategoryDialog from "@/modules/stores/components/dialogs/add-category";
+import { MainCategoriesTableV2 } from "./table-v2/MainCategoriesTableV2";
 
+/**
+ * Main Categories View - V2 Implementation
+ * Uses HeadlessTable with Two-Hook Pattern for better performance
+ */
 function MainCategoriesView() {
-  const [editingCategoryId, setEditingCategoryId] = useState<string | null>(
-    null
-  );
-  const tableConfig = useMainCategoryTableConfig({
-    onEdit: (id: string) => setEditingCategoryId(id),
-  });
-  const { reloadTable } = useTableReload(tableConfig.tableId);
-  const t = useTranslations();
+  const t = useTranslations("stores.mainCategories");
+  const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
+
   return (
     <>
       <Can check={[PERMISSIONS.ecommerce.category.update]}>
@@ -26,25 +22,14 @@ function MainCategoriesView() {
           open={Boolean(editingCategoryId)}
           onClose={() => setEditingCategoryId(null)}
           categoryId={editingCategoryId || undefined}
-          onSuccess={() => reloadTable()}
+          onSuccess={() => {
+            // Refetch will be handled by the table component
+            setEditingCategoryId(null);
+          }}
         />
       </Can>
-
-      <TableBuilder
-        config={tableConfig}
-        searchBarActions={
-          <Can check={[PERMISSIONS.ecommerce.category.create]}>
-            <DialogTrigger
-              component={AddCategoryDialog}
-              dialogProps={{ onSuccess: () => reloadTable() }}
-              render={({ onOpen }) => (
-                <Button onClick={onOpen}>اضافة قسم</Button>
-              )}
-            />
-          </Can>
-        }
-        tableId={tableConfig.tableId}
-      />
+      
+      <MainCategoriesTableV2 />
     </>
   );
 }

--- a/modules/stores/categories/list/views/main-category/table-v2/MainCategoriesTableV2.tsx
+++ b/modules/stores/categories/list/views/main-category/table-v2/MainCategoriesTableV2.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import HeadlessTableLayout from "@/components/headless/table";
+import { usePermissions } from "@/lib/permissions/client/permissions-provider";
+import { PERMISSIONS } from "@/lib/permissions/permission-names";
+import { apiClient, baseURL } from "@/config/axios-config";
+import { createColumns } from "./columns";
+import { TableFilters } from "./filters";
+import { RowActions } from "./actions";
+import { CategoryRow } from "./types";
+import AddCategoryDialog from "@/modules/stores/components/dialogs/add-category";
+import ConfirmDeleteDialog from "@/modules/company-profile/components/official-data/official-docs-section/docs-settings-dialog/AddDocumentType/ConfirmDeleteDialog";
+
+// Create typed table instance
+const CategoriesTable = HeadlessTableLayout<CategoryRow>();
+
+/**
+ * Main Categories Table V2 - HeadlessTable Implementation
+ * Migrated from old TableBuilder for better performance
+ * Features: Search, Pagination, CRUD operations with Two-Hook Pattern
+ */
+export function MainCategoriesTableV2() {
+  const { can } = usePermissions();
+  const t = useTranslations("stores.mainCategories");
+
+  // Dialog states
+  const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+
+  // Filter state
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // ✅ STEP 1: useTableParams (BEFORE query)
+  const params = CategoriesTable.useTableParams({
+    initialPage: 1,
+    initialLimit: 10,
+    initialSortBy: "name",
+    initialSortDirection: "asc",
+  });
+
+  // ✅ STEP 2: Fetch data using useQuery directly
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: [
+      "categories",
+      params.page,
+      params.limit,
+      params.sortBy,
+      params.sortDirection,
+      searchQuery,
+    ],
+    queryFn: async () => {
+      const response = await apiClient.get(
+        `${baseURL}/ecommerce/dashboard/categories?depth=0&page=${params.page}&per_page=${params.limit}&search=${searchQuery || ""}&sort_by=${params.sortBy}&sort_direction=${params.sortDirection}`
+      );
+      const result = await response.data;
+      return result;
+    },
+  });
+
+  // Extract data from response
+  const categories = useMemo<CategoryRow[]>(
+    () => data?.payload || [],
+    [data]
+  );
+
+  const totalPages = useMemo(
+    () => data?.pagination?.last_page || 1,
+    [data]
+  );
+
+  const totalItems = useMemo(
+    () => data?.pagination?.result_count || 0,
+    [data]
+  );
+
+  // Permission checks
+  const canEdit = can(PERMISSIONS.ecommerce.category.update);
+  const canDelete = can(PERMISSIONS.ecommerce.category.delete);
+
+  // Delete handlers
+  const handleDeleteClick = (id: string) => {
+    setDeleteConfirmId(id);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteConfirmId) return;
+    try {
+      await apiClient.delete(`${baseURL}/ecommerce/dashboard/categories/${deleteConfirmId}`);
+      refetch();
+      setDeleteConfirmId(null);
+    } catch (error) {
+      console.error("Delete failed:", error);
+    }
+  };
+
+  const cancelDelete = () => {
+    setDeleteConfirmId(null);
+  };
+
+  // Filter handlers
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    params.setPage(1);
+  };
+
+  const handleReset = () => {
+    setSearchQuery("");
+    params.reset();
+  };
+
+  // Table columns with actions
+  const columns = [
+    ...createColumns(t),
+    {
+      key: "actions",
+      name: t("table.actions"),
+      sortable: false,
+      render: (row: CategoryRow) => (
+        <RowActions
+          row={row}
+          onEdit={setEditingCategoryId}
+          onDelete={handleDeleteClick}
+          canEdit={canEdit}
+          canDelete={canDelete}
+          t={t}
+        />
+      ),
+    },
+  ];
+
+  // ✅ STEP 3: useTableState (AFTER query)
+  const state = CategoriesTable.useTableState({
+    data: categories,
+    columns,
+    totalPages,
+    totalItems,
+    params,
+    getRowId: (category) => category.id,
+    loading: isLoading,
+    filtered: searchQuery !== "",
+  });
+
+  return (
+    <>
+      <CategoriesTable
+        filters={
+          <TableFilters
+            searchQuery={searchQuery}
+            onSearchChange={handleSearchChange}
+            onReset={handleReset}
+            t={t}
+            setAddDialogOpen={setAddDialogOpen}
+            refetch={refetch}
+          />
+        }
+        table={<CategoriesTable.Table state={state} loadingOptions={{ rows: 5 }} />}
+        pagination={<CategoriesTable.Pagination state={state} />}
+      />
+
+      {/* Edit Dialog */}
+      {editingCategoryId && (
+        <AddCategoryDialog
+          open={Boolean(editingCategoryId)}
+          onClose={() => setEditingCategoryId(null)}
+          categoryId={editingCategoryId}
+          onSuccess={() => {
+            refetch();
+            setEditingCategoryId(null);
+          }}
+        />
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      <ConfirmDeleteDialog
+        open={Boolean(deleteConfirmId)}
+        onConfirm={confirmDelete}
+        onClose={cancelDelete}
+        title={t("table.deleteConfirm")}
+      />
+    </>
+  );
+}

--- a/modules/stores/categories/list/views/main-category/table-v2/actions.tsx
+++ b/modules/stores/categories/list/views/main-category/table-v2/actions.tsx
@@ -1,0 +1,89 @@
+import { Edit, MoreVertical, Trash } from "lucide-react";
+import { Button, IconButton, Menu, MenuItem } from "@mui/material";
+import { useState } from "react";
+import { CategoryRow } from "./types";
+
+interface RowActionsProps {
+  row: CategoryRow;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  canEdit: boolean;
+  canDelete: boolean;
+  t: (key: string) => string;
+}
+
+/**
+ * Row actions menu for Main Categories table
+ * Provides Edit action with permission checks
+ * Uses MUI Menu component for dropdown
+ */
+export function RowActions({
+  row,
+  onEdit,
+  onDelete,
+  canEdit,
+  canDelete,
+  t,
+}: RowActionsProps) {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleEdit = () => {
+    onEdit(row.id);
+    handleClose();
+  };
+
+  const handleDelete = () => {
+    onDelete(row.id);
+    handleClose();
+  };
+
+  return (
+    <>
+      <Button
+        size="small"
+        onClick={handleClick}
+        disabled={!canEdit && !canDelete}
+      >
+        {t("table.action")}
+        <MoreVertical size={16} />
+      </Button>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+      >
+        <MenuItem disabled={!canEdit} onClick={handleEdit}>
+          <Edit size={16} style={{ marginRight: "8px" }} />
+          {t("table.edit")}
+        </MenuItem>
+        
+        <MenuItem 
+          disabled={!canDelete} 
+          onClick={handleDelete}
+          style={{ color: "#d32f2f" }}
+        >
+          <Trash size={16} style={{ marginRight: "8px" }} />
+          {t("table.delete")}
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/modules/stores/categories/list/views/main-category/table-v2/columns.tsx
+++ b/modules/stores/categories/list/views/main-category/table-v2/columns.tsx
@@ -1,0 +1,64 @@
+import Image from "next/image";
+import { Box, Stack, Typography } from "@mui/material";
+import TheStatus from "../../../../component/the-status";
+import { CategoryRow } from "./types";
+
+/**
+ * Creates column definitions for the Main Categories table
+ * Handles image display, priority, and status with MUI components
+ */
+export const createColumns = (t: (key: string) => string) => {
+  return [
+    {
+      key: "name",
+      name: t("table.category"),
+      sortable: true,
+      render: (row: CategoryRow) => (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+          <Stack
+            sx={{
+              width: 48,
+              height: 48,
+              backgroundColor: "#f3f4f6",
+              borderRadius: 1,
+              overflow: "hidden",
+              position: "relative",
+            }}
+          >
+            {row.file?.url ? (
+              <Image
+                src={row.file.url}
+                alt={row.name}
+                fill
+                style={{ objectFit: "cover" }}
+              />
+            ) : (
+              <Typography variant="caption" sx={{ color: "#9ca3af" }}>
+                {t("table.image")}
+              </Typography>
+            )}
+          </Stack>
+          <Typography variant="body1" sx={{ fontWeight: 500 }}>
+            {row.name}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      key: "priority",
+      name: t("table.priority"),
+      sortable: true,
+      render: (row: CategoryRow) => (
+        <Typography variant="body2">{row.priority}</Typography>
+      ),
+    },
+    {
+      key: "is_active",
+      name: t("table.status"),
+      sortable: true,
+      render: (row: CategoryRow) => (
+        <TheStatus theStatus={row.is_active} id={row.id} />
+      ),
+    },
+  ];
+};

--- a/modules/stores/categories/list/views/main-category/table-v2/filters.tsx
+++ b/modules/stores/categories/list/views/main-category/table-v2/filters.tsx
@@ -1,0 +1,84 @@
+import { Search } from "lucide-react";
+import { useState, useEffect } from "react";
+import { Box, TextField, Button, Stack } from "@mui/material";
+import Can from "@/lib/permissions/client/Can";
+import { PERMISSIONS } from "@/lib/permissions/permission-names";
+import DialogTrigger from "@/components/headless/dialog-trigger";
+import AddCategoryDialog from "@/modules/stores/components/dialogs/add-category";
+
+interface TableFiltersProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  onReset: () => void;
+  t: (key: string) => string;
+  setAddDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  refetch: () => void;
+}
+
+/**
+ * Filters component for Main Categories table
+ * Provides search functionality with debounce and add button
+ * Uses MUI components for consistent UI
+ */
+export function TableFilters({
+  searchQuery,
+  onSearchChange,
+  onReset,
+  t,
+  setAddDialogOpen,
+  refetch,
+}: TableFiltersProps) {
+  const [localSearch, setLocalSearch] = useState(searchQuery);
+
+  // Sync with parent when searchQuery changes externally
+  useEffect(() => {
+    setLocalSearch(searchQuery);
+  }, [searchQuery]);
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (localSearch !== searchQuery) {
+        onSearchChange(localSearch);
+      }
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [localSearch, searchQuery, onSearchChange]);
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Stack direction="row" spacing={2} alignItems="center">
+        {/* Search input */}
+        <TextField
+          size="small"
+          placeholder={t("table.search")}
+          value={localSearch}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setLocalSearch(e.target.value)
+          }
+          InputProps={{
+            startAdornment: (
+              <Box component="span" sx={{ mr: 1, display: "flex" }}>
+                <Search size={16} style={{ color: "rgba(0, 0, 0, 0.54)" }} />
+              </Box>
+            ),
+          }}
+          sx={{ flexGrow: 1 }}
+        />
+
+        {/* Add category button */}
+        <Can check={[PERMISSIONS.ecommerce.category.create]}>
+          <DialogTrigger
+            component={AddCategoryDialog}
+            dialogProps={{ onSuccess: refetch }}
+            render={({ onOpen }) => (
+              <Button variant="contained" onClick={onOpen}>
+                {t("table.add")}
+              </Button>
+            )}
+          />
+        </Can>
+      </Stack>
+    </Box>
+  );
+}

--- a/modules/stores/categories/list/views/main-category/table-v2/index.ts
+++ b/modules/stores/categories/list/views/main-category/table-v2/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Table V2 Components Exports
+ * Modular components for the new HeadlessTable implementation
+ */
+export { createColumns } from "./columns";
+export { TableFilters } from "./filters";
+export { RowActions } from "./actions";

--- a/modules/stores/categories/list/views/main-category/table-v2/types.ts
+++ b/modules/stores/categories/list/views/main-category/table-v2/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Types for Main Categories table
+ * Defines the structure of category data used in the table
+ */
+
+import { Media } from "@/modules/docs-library/modules/publicDocs/types/Directory";
+
+export interface CategoryRow {
+  id: string;
+  name: string;
+  priority: string;
+  file?: Media;
+  is_active: "active" | "inActive";
+}

--- a/modules/stores/components/dialogs/add-category/index.tsx
+++ b/modules/stores/components/dialogs/add-category/index.tsx
@@ -134,14 +134,10 @@ export default function AddCategoryDialog({
     if (isEditMode && categoryData?.data?.payload) {
       const category = categoryData.data.payload;
 
-      setValue("name_ar", category.name || "");
-      setValue("name_en", category.name || "");
-      setValue("priority", String(category.priority || 1));
-
-      // Set image preview if exists
-      if (category.category_image) {
-        setImagePreview(category.category_image);
-      }
+      setValue("name_ar", category?.name_ar || "");
+      setValue("name_en", category?.name_en || "");
+      setValue("priority", String(category?.priority || 1));
+      setImagePreview(category.category_image ?? category?.file?.url ?? "");
     }
   }, [isEditMode, categoryData, setValue]);
 

--- a/modules/stores/warehouse/list/index.tsx
+++ b/modules/stores/warehouse/list/index.tsx
@@ -1,54 +1,14 @@
 "use client";
 
-import { TableBuilder, useTableReload } from "@/modules/table";
-import { Button } from "@/components/ui/button";
-import DialogTrigger from "@/components/headless/dialog-trigger";
-import AddWarehouse2Dialog from "@/modules/stores/components/dialogs/add-warehouse-2";
-import { useTranslations } from "next-intl";
-import { useWarehousesListTablConfig } from "../_config/list-table-config";
-import { useState } from "react";
 import StatisticsStoreRow from "@/components/shared/layout/statistics-store";
 import { statisticsConfig } from "../component/statistics-config";
-import { PERMISSIONS } from "@/lib/permissions/permission-names";
-import Can from "@/lib/permissions/client/Can";
+import { WarehousesTableV2 } from "../table-v2/WarehousesTableV2";
 
 function ListWarehousesView() {
-  const [editingWarehouseId, setEditingWarehouseId] = useState<string | null>(
-    null
-  );
-  const tableConfig = useWarehousesListTablConfig({
-    onEdit: (id: string) => setEditingWarehouseId(id),
-  });
-  const { reloadTable } = useTableReload(tableConfig.tableId);
-  const t = useTranslations();
   return (
     <>
       <StatisticsStoreRow config={statisticsConfig} />
-      <Can check={[PERMISSIONS.ecommerce.warehouse.update]}>
-        <AddWarehouse2Dialog
-          open={Boolean(editingWarehouseId)}
-          onClose={() => setEditingWarehouseId(null)}
-          warehouseId={editingWarehouseId || undefined}
-          onSuccess={() => reloadTable()}
-        />
-      </Can>
-      <TableBuilder
-        config={tableConfig}
-        searchBarActions={
-          <Can check={[PERMISSIONS.ecommerce.warehouse.create]}>
-            <DialogTrigger
-              component={AddWarehouse2Dialog}
-              dialogProps={{ onSuccess: () => reloadTable() }}
-              render={({ onOpen }) => (
-                <Button onClick={onOpen}>
-                  {t("labels.add")} {t("warehouse.singular")}
-                </Button>
-              )}
-            />
-          </Can>
-        }
-        tableId={tableConfig.tableId}
-      />
+      <WarehousesTableV2 />
     </>
   );
 }

--- a/modules/stores/warehouse/table-v2/WarehousesTableV2.tsx
+++ b/modules/stores/warehouse/table-v2/WarehousesTableV2.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import HeadlessTableLayout from "@/components/headless/table";
+import { usePermissions } from "@/lib/permissions/client/permissions-provider";
+import { PERMISSIONS } from "@/lib/permissions/permission-names";
+import { apiClient, baseURL } from "@/config/axios-config";
+import { createColumns } from "./columns";
+import { TableFilters } from "./filters";
+import { RowActions } from "./actions";
+import { WarehouseRow } from "./types";
+import AddWarehouse2Dialog from "@/modules/stores/components/dialogs/add-warehouse-2";
+import ConfirmDeleteDialog from "@/modules/company-profile/components/official-data/official-docs-section/docs-settings-dialog/AddDocumentType/ConfirmDeleteDialog";
+
+// Create typed table instance
+const WarehousesTable = HeadlessTableLayout<WarehouseRow>();
+
+/**
+ * Warehouses Table V2 - HeadlessTable Implementation
+ * Migrated from old TableBuilder for better performance
+ * Features: Search, Pagination, CRUD operations with Two-Hook Pattern
+ */
+export function WarehousesTableV2() {
+  const { can } = usePermissions();
+  const t = useTranslations("stores.warehouse");
+
+  // Dialog states
+  const [editingWarehouseId, setEditingWarehouseId] = useState<string | null>(null);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+
+  // Filter state
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // ✅ STEP 1: useTableParams (BEFORE query)
+  const params = WarehousesTable.useTableParams({
+    initialPage: 1,
+    initialLimit: 10,
+    initialSortBy: "name",
+    initialSortDirection: "asc",
+  });
+
+  // ✅ STEP 2: Fetch data using useQuery directly
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: [
+      "warehouses",
+      params.page,
+      params.limit,
+      params.sortBy,
+      params.sortDirection,
+      searchQuery,
+    ],
+    queryFn: async () => {
+      const response = await apiClient.get(
+        `${baseURL}/ecommerce/warehouses?page=${params.page}&per_page=${params.limit}&search=${searchQuery || ""}&sort_by=${params.sortBy}&sort_direction=${params.sortDirection}`
+      );
+      return response.data;
+    },
+  });
+
+  // Extract data from response
+  const warehouses = useMemo<WarehouseRow[]>(
+    () => data?.payload || [],
+    [data]
+  );
+
+  const totalPages = useMemo(
+    () => data?.pagination?.last_page || 1,
+    [data]
+  );
+
+  const totalItems = useMemo(
+    () => data?.pagination?.result_count || 0,
+    [data]
+  );
+
+  // Permission checks
+  const canEdit = can(PERMISSIONS.ecommerce.warehouse.update);
+  const canDelete = can(PERMISSIONS.ecommerce.warehouse.delete);
+
+  // Delete handlers
+  const handleDeleteClick = (id: string) => {
+    setDeleteConfirmId(id);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteConfirmId) return;
+    try {
+      await apiClient.delete(`${baseURL}/ecommerce/warehouses/${deleteConfirmId}`);
+      refetch();
+      setDeleteConfirmId(null);
+    } catch (error) {
+      console.error("Delete failed:", error);
+    }
+  };
+
+  const cancelDelete = () => {
+    setDeleteConfirmId(null);
+  };
+
+  // Filter handlers
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    params.setPage(1);
+  };
+
+  const handleReset = () => {
+    setSearchQuery("");
+    params.reset();
+  };
+
+  // Table columns with actions
+  const columns = [
+    ...createColumns(t),
+    {
+      key: "actions",
+      name: t("table.actions"),
+      sortable: false,
+      render: (row: WarehouseRow) => (
+        <RowActions
+          row={row}
+          onEdit={setEditingWarehouseId}
+          onDelete={handleDeleteClick}
+          canEdit={canEdit}
+          canDelete={canDelete}
+          t={t}
+        />
+      ),
+    },
+  ];
+
+  // ✅ STEP 3: useTableState (AFTER query)
+  const state = WarehousesTable.useTableState({
+    data: warehouses,
+    columns,
+    totalPages,
+    totalItems,
+    params,
+    getRowId: (warehouse) => warehouse.id,
+    loading: isLoading,
+    filtered: searchQuery !== "",
+  });
+
+  return (
+    <>
+      <WarehousesTable
+        filters={
+          <TableFilters
+            searchQuery={searchQuery}
+            onSearchChange={handleSearchChange}
+            onReset={handleReset}
+            t={t}
+            refetch={refetch}
+          />
+        }
+        table={<WarehousesTable.Table state={state} loadingOptions={{ rows: 5 }} />}
+        pagination={<WarehousesTable.Pagination state={state} />}
+      />
+
+      {/* Edit Dialog */}
+      {editingWarehouseId && (
+        <AddWarehouse2Dialog
+          warehouseId={editingWarehouseId}
+          open={Boolean(editingWarehouseId)}
+          onClose={() => setEditingWarehouseId(null)}
+          onSuccess={() => {
+            refetch();
+            setEditingWarehouseId(null);
+          }}
+        />
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      <ConfirmDeleteDialog
+        open={Boolean(deleteConfirmId)}
+        onConfirm={confirmDelete}
+        onClose={cancelDelete}
+        title={t("deleteConfirmMessage")}
+      />
+    </>
+  );
+}

--- a/modules/stores/warehouse/table-v2/actions.tsx
+++ b/modules/stores/warehouse/table-v2/actions.tsx
@@ -1,0 +1,89 @@
+import { Edit, MoreVertical, Trash } from "lucide-react";
+import { Button, IconButton, Menu, MenuItem } from "@mui/material";
+import { useState } from "react";
+import { WarehouseRow } from "./types";
+
+interface RowActionsProps {
+  row: WarehouseRow;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  canEdit: boolean;
+  canDelete: boolean;
+  t: (key: string) => string;
+}
+
+/**
+ * Row actions menu for Warehouse table
+ * Provides Edit and Delete actions with permission checks
+ * Uses MUI Menu component for dropdown
+ */
+export function RowActions({
+  row,
+  onEdit,
+  onDelete,
+  canEdit,
+  canDelete,
+  t,
+}: RowActionsProps) {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleEdit = () => {
+    onEdit(row.id);
+    handleClose();
+  };
+
+  const handleDelete = () => {
+    onDelete(row.id);
+    handleClose();
+  };
+
+  return (
+    <>
+      <Button
+        size="small"
+        onClick={handleClick}
+        disabled={!canEdit && !canDelete}
+      >
+        {t("table.action")}
+        <MoreVertical size={16} />
+      </Button>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+      >
+        <MenuItem disabled={!canEdit} onClick={handleEdit}>
+          <Edit size={16} style={{ marginRight: "8px" }} />
+          {t("table.edit")}
+        </MenuItem>
+        
+        <MenuItem 
+          disabled={!canDelete} 
+          onClick={handleDelete}
+          style={{ color: "#d32f2f" }}
+        >
+          <Trash size={16} style={{ marginRight: "8px" }} />
+          {t("table.delete")}
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/modules/stores/warehouse/table-v2/columns.tsx
+++ b/modules/stores/warehouse/table-v2/columns.tsx
@@ -1,0 +1,55 @@
+import { Switch } from "@mui/material";
+import { WarehouseRow } from "./types";
+
+/**
+ * Creates column definitions for the Warehouse table
+ * Handles location data and default status with MUI components
+ */
+export const createColumns = (t: (key: string) => string) => {
+  return [
+    {
+      key: "name",
+      name: t("table.name"),
+      sortable: true,
+      render: (row: WarehouseRow) => row.name,
+    },
+    {
+      key: "country",
+      name: t("table.location.country"),
+      sortable: true,
+      render: (row: WarehouseRow) => row.country?.name || "-",
+    },
+    {
+      key: "city",
+      name: t("table.location.city"),
+      sortable: true,
+      render: (row: WarehouseRow) => row.city?.name || "-",
+    },
+    {
+      key: "district",
+      name: t("table.location.district"),
+      sortable: true,
+      render: (row: WarehouseRow) => row.district || "-",
+    },
+    {
+      key: "longitude",
+      name: t("table.location.longitude"),
+      sortable: true,
+      render: (row: WarehouseRow) => row.longitude || "-",
+    },
+    {
+      key: "latitude",
+      name: t("table.location.latitude"),
+      sortable: true,
+      render: (row: WarehouseRow) => row.latitude || "-",
+    },
+    {
+      key: "is_default",
+      name: t("table.default"),
+      sortable: true,
+      render: (row: WarehouseRow) => (
+        <Switch checked={Boolean(row.is_default)} disabled />
+      ),
+    },
+  ];
+};

--- a/modules/stores/warehouse/table-v2/filters.tsx
+++ b/modules/stores/warehouse/table-v2/filters.tsx
@@ -1,0 +1,86 @@
+import { Search, RefreshCw } from "lucide-react";
+import { useState, useEffect } from "react";
+import { Box, TextField, Button, Stack } from "@mui/material";
+import Can from "@/lib/permissions/client/Can";
+import { PERMISSIONS } from "@/lib/permissions/permission-names";
+import DialogTrigger from "@/components/headless/dialog-trigger";
+import AddWarehouse2Dialog from "@/modules/stores/components/dialogs/add-warehouse-2";
+
+interface TableFiltersProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  onReset: () => void;
+  t: (key: string) => string;
+  refetch: () => void;
+}
+
+/**
+ * Filters component for Warehouse table
+ * Provides search functionality with debounce and add button
+ * Uses MUI components for consistent UI
+ */
+export function TableFilters({
+  searchQuery,
+  onSearchChange,
+  onReset,
+  t,
+  refetch,
+}: TableFiltersProps) {
+  const [localSearch, setLocalSearch] = useState(searchQuery);
+
+  // Sync with parent when searchQuery changes externally
+  useEffect(() => {
+    setLocalSearch(searchQuery);
+  }, [searchQuery]);
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (localSearch !== searchQuery) {
+        onSearchChange(localSearch);
+      }
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [localSearch, searchQuery, onSearchChange]);
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Stack direction="row" spacing={2} alignItems="center">
+        {/* Search input */}
+        <TextField
+          size="small"
+          placeholder={t("table.search")}
+          value={localSearch}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setLocalSearch(e.target.value)
+          }
+          InputProps={{
+            startAdornment: (
+              <Box component="span" sx={{ mr: 1, display: "flex" }}>
+                <Search size={16} style={{ color: "rgba(0, 0, 0, 0.54)" }} />
+              </Box>
+            ),
+          }}
+          sx={{ flexGrow: 1 }}
+        />
+
+        {/* Add warehouse button */}
+        <Can check={[PERMISSIONS.ecommerce.warehouse.create]}>
+          <DialogTrigger
+            component={AddWarehouse2Dialog}
+            dialogProps={{
+              onSuccess: () => {
+                refetch();
+              },
+            }}
+            render={({ onOpen }) => (
+              <Button variant="contained" onClick={onOpen}>
+                {t("table.add")}
+              </Button>
+            )}
+          />
+        </Can>
+      </Stack>
+    </Box>
+  );
+}

--- a/modules/stores/warehouse/table-v2/index.ts
+++ b/modules/stores/warehouse/table-v2/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Table V2 Components Exports
+ * Modular components for the new HeadlessTable implementation
+ */
+export { createColumns } from "./columns";
+export { TableFilters } from "./filters";
+export { RowActions } from "./actions";
+export type { WarehouseRow } from "./types";

--- a/modules/stores/warehouse/table-v2/types.ts
+++ b/modules/stores/warehouse/table-v2/types.ts
@@ -1,0 +1,8 @@
+/**
+ * Types for Warehouse table
+ * Defines the structure of warehouse data used in the table
+ */
+
+import { ECM_Warehouse_ListItem } from "@/types/api/ecommerce/warehouse";
+
+export type WarehouseRow = ECM_Warehouse_ListItem;

--- a/types/api/ecommerce/category/index.ts
+++ b/types/api/ecommerce/category/index.ts
@@ -1,10 +1,15 @@
+import { Media } from "@/modules/docs-library/modules/publicDocs/types/Directory";
+
 export interface ECM_Category {
   id: string;
   name: string;
+  name_ar?: string;
+  name_en?: string;
   description?: string;
   parent?: ECM_CategoryParent | null;
   category_image?: string;
   priority?: number;
+  file?: Media;
 }
 
 export interface ECM_CategoryParent {


### PR DESCRIPTION
…ttern and add stores messages structure

- Created stores messages group with main categories translations for table UI elements
- Migrated MainCategoriesView from TableBuilder to HeadlessTableV2 implementation
- Implemented two-hook pattern with useTableParams (before query) and useTableState (after query)
- Added MainCategoriesTableV2 component with direct useQuery integration for better performance
- Created modular table components
<!-- Provide a brief summary of your changes -->

### Jira Ticket:
[CO-902](https://new-vision.atlassian.net/browse/CO-902)
[CO-904](https://new-vision.atlassian.net/browse/CO-904)

<!-- Required: Enter Jira ticket ID (e.g., CORE-123) or full link -->

### Backend URL: 

<!-- Enter Linked BE URL - It will point to related Branch (dev / stage / master) -->

BE_URL: dev

---

## Visual Changes

### Screenshots - Before & After

<!-- Add screenshots showing the changes. Use tables for side-by-side comparison -->

| Before         | After         |
| -------------- | ------------- |
| ![before](
<img width="2547" height="1245" alt="image" src="https://github.com/user-attachments/assets/00813655-ec32-476c-b30f-c7dfe1536ef1" />

<img width="2553" height="1260" alt="image" src="https://github.com/user-attachments/assets/96cc507c-73a3-4c77-bc94-6a0288f16b8c" />


) | ![after](
<img width="2559" height="1247" alt="image" src="https://github.com/user-attachments/assets/7bba7fb9-fad5-4c0d-a458-8ce5bd2cbf8c" />

<img width="2528" height="1239" alt="image" src="https://github.com/user-attachments/assets/ea95390d-95d0-44f2-b792-f42d32bde406" />

) |

### Responsive Views

<!-- Add screenshots for different breakpoints -->

<details>
<summary>📱 Mobile View</summary>

![Mobile Screenshot](url)

</details>

<details>
<summary>💻 Tablet View</summary>

![Tablet Screenshot](url)

</details>

<details>
<summary>🖥️ Desktop View</summary>

<img width="2559" height="1247" alt="image" src="https://github.com/user-attachments/assets/071a8415-cb91-4e99-ae81-ee74715f1290" />
</details>

---

## Technical Details

### Components Modified/Added

<!-- List the main components affected -->

-

### API Integrations

<!-- Describe any new API endpoints or changes to existing ones -->

- ***

## Testing

### Manual Testing Checklist

- [x] Tested on Chrome
- [x] Tested all user interactions
- [x] Tested error states
- [x] Tested loading states
- [x] Verified responsive behavior
- [x] Tested with Arabic language (RTL)
- [x] Tested with English language (LTR)

---

## Dependencies

- [x] No new dependencies added
- [ ] New dependencies added (list below with justification)
- [ ] Dependencies updated (list below with reason)

**Details:**

<!-- If checked above, provide details -->

---

## Deployment Notes

- [x] No special deployment steps required
- [ ] Requires environment variables (specify below)
- [ ] Requires migration/setup steps (specify below)
- [ ] Has backend dependencies (ensure BE_URL is correct)

**Details:**

<!-- If checked above, provide details -->

---

## Quality Checklist

- [x] Self-reviewed the code
- [x] No console errors or warnings
- [x] Translations added for both Arabic and English
- [x] TypeScript types properly defined
- [x] Code follows project conventions
---

## Types of Changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Code style update (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement


[CO-902]: https://new-vision.atlassian.net/browse/CO-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CO-904]: https://new-vision.atlassian.net/browse/CO-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ